### PR TITLE
Add llvm-xtensa and ldc-xtensa images

### DIFF
--- a/definitions/containerfiles.ini
+++ b/definitions/containerfiles.ini
@@ -528,3 +528,13 @@ level = false
 
 [llvm:18.1.8]
 level = false
+
+[ldc-xtensa:1.39.0]
+level = 2.109.1
+dependencies[] = llvm-xtensa:16.0
+dependencies[] = ldc:1.20
+extras[dub] = 1.38.0
+
+[llvm-xtensa:16.0.4]
+level = false
+env[GIT_TAG] = esp-16.0.4-20231113

--- a/templates/ldc-xtensa/ldc-xtensa-image.containerfile
+++ b/templates/ldc-xtensa/ldc-xtensa-image.containerfile
@@ -1,0 +1,57 @@
+{{< ldc/ldc-variables.php }}
+###################
+# imported images #
+###################
+
+FROM {{ $container_namespace }}/llvm-xtensa:{{ $dependencies['llvm-xtensa'] }}-{{ $base_image_alias }} AS llvm-imported
+{{# if ($isBootstrappedByLDC): }}
+	FROM {{ $container_namespace }}/ldc:{{ $dependencies['ldc'] }}-{{ $base_image_alias }} AS ldc-bootstrap-imported
+{{# endif }}
+
+###############
+# build stage #
+###############
+
+{{< ldc/ldc-image-build-stage.containerfile }}
+
+{{# if ($isBootstrappedByLDC): }}
+
+	##################
+	# self bootstrap #
+	##################
+
+	{{< ldc/ldc-image-build-stage.containerfile }}
+{{# endif }}
+
+{{< common/make-dub.containerfile }}
+
+{{< common/make-d-tools.containerfile }}
+
+################
+# export stage #
+################
+
+{{# $buildStage = "build-stage-{$buildStageCounter}"; }}
+FROM {{ $base_image }} AS export-stage
+
+{{< common/prepare-runtime-environment.containerfile }}
+
+COPY --from={{ $buildStage }} /opt/ldc /opt/ldc
+
+{{< d-tools/install-d-tools.containerfile }}
+
+# Self-test
+COPY ./resources/helloworld.d /opt/helloworld.d
+RUN /opt/ldc/bin/ldmd2 -run /opt/helloworld.d
+RUN rm /opt/helloworld.d
+
+{{# if (isset($extras['dub'])): }}
+	COPY --from={{ $buildStage }} /opt/build/dub/bin/dub /usr/bin/dub
+{{# endif }}
+
+{{< d-tools/install-d-tools.containerfile }}
+
+COPY ./templates/scripts/entrypoint-ldc.sh /usr/bin/entrypoint
+
+ENTRYPOINT [ "/usr/bin/entrypoint" ]
+CMD [ "/opt/ldc/bin/ldc2" ]

--- a/templates/llvm-xtensa/download-llvm-xtensa-source.containerfile
+++ b/templates/llvm-xtensa/download-llvm-xtensa-source.containerfile
@@ -1,0 +1,7 @@
+## Download LLVM source
+
+{{# if (!isset($GIT_TAG)): }}
+	!!! Error: $GIT_TAG is not set !!!
+{{# else: }}
+    RUN curl -fLsSo llvm.tar.gz "https://github.com/espressif/llvm-project/archive/refs/tags/{{ $GIT_TAG }}.tar.gz"
+{{# endif }}

--- a/templates/llvm-xtensa/llvm-xtensa-image.containerfile
+++ b/templates/llvm-xtensa/llvm-xtensa-image.containerfile
@@ -1,0 +1,29 @@
+<?php
+	$LLVM_EXPERIMENTAL_TARGETS_TO_BUILD = "Xtensa"
+?>
+
+###############
+# build stage #
+###############
+
+FROM {{ $base_image }} AS build-stage
+
+WORKDIR /opt/build
+
+# Install dependencies
+{{< common/install-common-system-tools.containerfile }}
+{{< llvm/install-llvm-build-deps.containerfile }}
+
+# Download, build and install LLVM
+{{< llvm-xtensa/download-llvm-xtensa-source.containerfile }}
+{{< llvm/build-llvm.containerfile }}
+
+################
+# export stage #
+################
+
+FROM {{ $base_image }} AS export-stage
+
+COPY --from=build-stage /opt/llvm/ /opt/llvm/
+
+CMD ["echo", "This image is not meant to be run. It only provides files located in /opt/llvm."]

--- a/templates/llvm/build-llvm.containerfile
+++ b/templates/llvm/build-llvm.containerfile
@@ -21,6 +21,9 @@ RUN cmake \
 	{{# if ($semver->major >= 12): }}
 		-DLLVM_ENABLE_RUNTIMES=compiler-rt \
 	{{# endif }}
+	{{# if (isset($LLVM_EXPERIMENTAL_TARGETS_TO_BUILD)): }}
+		-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="{{ $LLVM_EXPERIMENTAL_TARGETS_TO_BUILD }}" \
+	{{# endif }}
 	-DCMAKE_INSTALL_PREFIX=/opt/llvm \
 	-DCMAKE_C_COMPILER=gcc \
 	-DCMAKE_CXX_COMPILER=g++ \


### PR DESCRIPTION
Builds llvm from https://github.com/espressif/llvm-project, and ldc with that llvm build.
These are seperate images from ldc and llvm because I can't find any good way to add this along the existing ldc and llvm version tags.
Currently building with `./ddct ldc-xtensa 1.39 ` one last time from scratch. Will confirm here if it works.

Upstream llvm has very limited Xtensa support which is easy to enable as experimental target, and might be done even by upstream ldc (https://github.com/ldc-developers/ldc/issues/4725), as is already the case with SPIR-V.
To actually compile for xtensa esp32 chips, you need the not-yet-upstreamed espressif fork of llvm.